### PR TITLE
Fix 9 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/folder/package.json
+++ b/folder/package.json
@@ -6,9 +6,9 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "3.13.0",
-    "marked": "0.3.15",
-    "canvas": "1.6.9"
+    "js-yaml": "3.13.1",
+    "marked": "0.6.2",
+    "canvas": "1.6.10"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "3.13.0",
-    "marked": "0.3.15",
-    "canvas": "1.6.9"
+    "js-yaml": "3.13.1",
+    "marked": "0.6.2",
+    "canvas": "1.6.10"
   },
   "standard": {
     "globals": [

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
 <properties>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <surefire.version>2.0.1</surefire.version>
+    <surefire.version>2.5.10.1</surefire.version>
 </properties>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.struts</groupId>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # comment
-urllib3===1.24.1 # comment
+urllib3 == 1.24.3 # comment
 mysql-connector== ^1.0.0
 sdfsdf==1.0.0


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Tue, 29 Jun 2021 14:04:47 IDT

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540) | 9.8 | fixed in 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335) | 9.8 | fixed in 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-17267](https://nvd.nist.gov/vuln/detail/CVE-2019-17267) | 9.8 | fixed in 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-20330](https://nvd.nist.gov/vuln/detail/CVE-2019-20330) | 9.8 | fixed in 2.9.10.2 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9546](https://nvd.nist.gov/vuln/detail/CVE-2020-9546) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9548](https://nvd.nist.gov/vuln/detail/CVE-2020-9548) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9547](https://nvd.nist.gov/vuln/detail/CVE-2020-9547) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11619](https://nvd.nist.gov/vuln/detail/CVE-2020-11619) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11620](https://nvd.nist.gov/vuln/detail/CVE-2020-11620) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19361](https://nvd.nist.gov/vuln/detail/CVE-2018-19361) | 9.8 | fixed in 2.9.8 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14893](https://nvd.nist.gov/vuln/detail/CVE-2019-14893) | 9.8 | fixed in 2.10.0, 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14379](https://nvd.nist.gov/vuln/detail/CVE-2019-14379) | 9.8 | fixed in 2.9.9.2 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-11307](https://nvd.nist.gov/vuln/detail/CVE-2018-11307) | 9.8 | fixed in 2.9.6, 2.8.11.2 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14892](https://nvd.nist.gov/vuln/detail/CVE-2019-14892) | 9.8 | fixed in 2.9.10, 2.8.11.5, 2.6.7.3 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19360](https://nvd.nist.gov/vuln/detail/CVE-2018-19360) | 9.8 | fixed in 2.9.8 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19362](https://nvd.nist.gov/vuln/detail/CVE-2018-19362) | 9.8 | fixed in 2.9.8 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14721](https://nvd.nist.gov/vuln/detail/CVE-2018-14721) | 10.0 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14720](https://nvd.nist.gov/vuln/detail/CVE-2018-14720) | 9.8 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14719](https://nvd.nist.gov/vuln/detail/CVE-2018-14719) | 9.8 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14718](https://nvd.nist.gov/vuln/detail/CVE-2018-14718) | 9.8 | fixed in 2.9.7 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2016-4436](https://nvd.nist.gov/vuln/detail/CVE-2016-4436) | 9.8 | fixed in 2.5.1, 2.3.29 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2017-12611](https://nvd.nist.gov/vuln/detail/CVE-2017-12611) | 9.8 | fixed in 2.5.10.1, 2.3.34 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2016-3082](https://nvd.nist.gov/vuln/detail/CVE-2016-3082) | 9.8 | fixed in 2.3.28.1, 2.3.24.2, 2.3.20.2 | 
high | requirements.txt | urllib3 | [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324) | 7.5 | fixed in 1.24.2 | 
high | package.json | js-yaml | [NODE-SECURITY-813](https://github.com/advisories/813) | 7.0 | fixed in >=3.13.1 | 
high | folder/package.json | js-yaml | [NODE-SECURITY-813](https://github.com/advisories/813) | 7.0 | fixed in >=3.13.1 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10673](https://nvd.nist.gov/vuln/detail/CVE-2020-10673) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10672](https://nvd.nist.gov/vuln/detail/CVE-2020-10672) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10968](https://nvd.nist.gov/vuln/detail/CVE-2020-10968) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10969](https://nvd.nist.gov/vuln/detail/CVE-2020-10969) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11111](https://nvd.nist.gov/vuln/detail/CVE-2020-11111) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11112](https://nvd.nist.gov/vuln/detail/CVE-2020-11112) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11113](https://nvd.nist.gov/vuln/detail/CVE-2020-11113) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14439](https://nvd.nist.gov/vuln/detail/CVE-2019-14439) | 7.5 | fixed in 2.9.9.2 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-12022](https://nvd.nist.gov/vuln/detail/CVE-2018-12022) | 7.5 | fixed in 2.9.6, 2.8.11.2, 2.7.9.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-12023](https://nvd.nist.gov/vuln/detail/CVE-2018-12023) | 7.5 | fixed in 2.9.6, 2.8.11.2, 2.7.9.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086) | 7.5 | fixed in 2.9.9 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-4461](https://nvd.nist.gov/vuln/detail/CVE-2016-4461) | 8.8 | fixed in 2.3.29 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-0785](https://nvd.nist.gov/vuln/detail/CVE-2016-0785) | 8.8 | fixed in 2.3.28 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-3081](https://nvd.nist.gov/vuln/detail/CVE-2016-3081) | 8.1 | fixed in 2.3.28.1 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-3090](https://nvd.nist.gov/vuln/detail/CVE-2016-3090) | 8.8 | fixed in 2.3.20 | 
medium | requirements.txt | urllib3 | [CVE-2019-11236](https://nvd.nist.gov/vuln/detail/CVE-2019-11236) | 6.1 | fixed in 1.24.3 | 
moderate | package.json | marked | [NODE-SECURITY-812](https://github.com/advisories/812) | 4.0 | fixed in >=0.6.2 | 
moderate | package.json | marked | [NODE-SECURITY-812111](https://github.com/advisories/812) | 4.0 | fixed in >=0.6.1 | 
moderate | package.json | canvas | [NODE-SECURITY-804](https://github.com/advisories/804) | 4.0 | fixed in >=1.6.10 | 
moderate | folder/package.json | marked | [NODE-SECURITY-812](https://github.com/advisories/812) | 4.0 | fixed in >=0.6.2 | 
moderate | folder/package.json | marked | [NODE-SECURITY-812111](https://github.com/advisories/812) | 4.0 | fixed in >=0.6.1 | 
moderate | folder/package.json | canvas | [NODE-SECURITY-804](https://github.com/advisories/804) | 4.0 | fixed in >=1.6.10 | 
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-1000873](https://nvd.nist.gov/vuln/detail/CVE-2018-1000873) | 6.5 | fixed in 2.9.8 | 
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12384](https://nvd.nist.gov/vuln/detail/CVE-2019-12384) | 5.9 | fixed in 2.9.9.1 | 
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12814](https://nvd.nist.gov/vuln/detail/CVE-2019-12814) | 5.9 | fixed in 2.9.9.1 | 
medium | pom.xml | org.apache.struts_struts-core | [CVE-2016-4003](https://nvd.nist.gov/vuln/detail/CVE-2016-4003) | 6.1 | fixed in 2.3.28, 1.8 | 
medium | pom.xml | org.apache.struts_struts-core | [CVE-2016-2162](https://nvd.nist.gov/vuln/detail/CVE-2016-2162) | 6.1 | fixed in 2.3.25 | 
