### PR TITLE
Fix 12 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/folder/package.json
+++ b/folder/package.json
@@ -6,9 +6,9 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "3.13.0",
-    "marked": "0.3.15",
-    "canvas": "1.6.9"
+    "js-yaml": "3.13.1",
+    "marked": "1.1.1",
+    "canvas": "1.6.10"
   },
   "standard": {
     "globals": [

--- a/folder/requirements.txt
+++ b/folder/requirements.txt
@@ -1,7 +1,7 @@
-pyyaml==0.1
+pyyaml == 5.4 
 python-telegram-bot
 python-bugzilla
 pymongo
 telegram
 validate_email
-werkzeug==0.1
+werkzeug == 0.15.3 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "3.13.0",
-    "marked": "0.3.15",
-    "canvas": "1.6.9"
+    "js-yaml": "3.13.1",
+    "marked": "1.1.1",
+    "canvas": "1.6.10"
   },
   "standard": {
     "globals": [

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
 <properties>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <surefire.version>2.0.1</surefire.version>
+    <surefire.version>2.5.26</surefire.version>
 </properties>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version> <!-- ==> 2.10.0   -->
+      <version>2.10.5.1</version> <!-- ==> 2.10.0   -->
     </dependency>
     <dependency>
       <groupId>org.apache.struts</groupId>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # comment
-urllib3===1.24.1 # comment --> 1.24.3
+urllib3 == 1.25.9 # comment --> 1.24.3
 mysql-connector== ^1.0.0
 sdfsdf==1.0.0 
-werkzeug==0.1
+werkzeug == 0.15.3 


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Sun, 11 Jul 2021 15:25:31 IDT

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | folder/requirements.txt | pyyaml | [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342) | 9.8 | fixed in 5.1 | 
critical | folder/requirements.txt | pyyaml | [CVE-2020-14343](https://nvd.nist.gov/vuln/detail/CVE-2020-14343) | 9.8 | fixed in 5.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14718](https://nvd.nist.gov/vuln/detail/CVE-2018-14718) | 9.8 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14719](https://nvd.nist.gov/vuln/detail/CVE-2018-14719) | 9.8 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14720](https://nvd.nist.gov/vuln/detail/CVE-2018-14720) | 9.8 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14721](https://nvd.nist.gov/vuln/detail/CVE-2018-14721) | 10.0 | fixed in 2.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19360](https://nvd.nist.gov/vuln/detail/CVE-2018-19360) | 9.8 | fixed in 2.9.8 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19361](https://nvd.nist.gov/vuln/detail/CVE-2018-19361) | 9.8 | fixed in 2.9.8 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19362](https://nvd.nist.gov/vuln/detail/CVE-2018-19362) | 9.8 | fixed in 2.9.8 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14379](https://nvd.nist.gov/vuln/detail/CVE-2019-14379) | 9.8 | fixed in 2.9.9.2 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540) | 9.8 | fixed in 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14892](https://nvd.nist.gov/vuln/detail/CVE-2019-14892) | 9.8 | fixed in 2.9.10, 2.8.11.5, 2.6.7.3 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14893](https://nvd.nist.gov/vuln/detail/CVE-2019-14893) | 9.8 | fixed in 2.10.0, 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335) | 9.8 | fixed in 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16942](https://nvd.nist.gov/vuln/detail/CVE-2019-16942) | 9.8 | fixed in 2.9.10.1, 2.8.11.5, 2.6.7.3 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16943](https://nvd.nist.gov/vuln/detail/CVE-2019-16943) | 9.8 | fixed in 2.9.10.1, 2.8.11.5, 2.6.7.3 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-17267](https://nvd.nist.gov/vuln/detail/CVE-2019-17267) | 9.8 | fixed in 2.9.10 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-17531](https://nvd.nist.gov/vuln/detail/CVE-2019-17531) | 9.8 | fixed in 2.9.10.1, 2.8.11.5, 2.6.7.3 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-20330](https://nvd.nist.gov/vuln/detail/CVE-2019-20330) | 9.8 | fixed in 2.9.10.2 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-8840](https://nvd.nist.gov/vuln/detail/CVE-2020-8840) | 9.8 | fixed in 2.9.10.3, 2.8.11.5, 2.7.9.7 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9546](https://nvd.nist.gov/vuln/detail/CVE-2020-9546) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9547](https://nvd.nist.gov/vuln/detail/CVE-2020-9547) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9548](https://nvd.nist.gov/vuln/detail/CVE-2020-9548) | 9.8 | fixed in 2.9.10.4 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2016-3082](https://nvd.nist.gov/vuln/detail/CVE-2016-3082) | 9.8 | fixed in 2.3.28.1, 2.3.24.2, 2.3.20.2 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2016-4436](https://nvd.nist.gov/vuln/detail/CVE-2016-4436) | 9.8 | fixed in 2.5.1, 2.3.29 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2017-12611](https://nvd.nist.gov/vuln/detail/CVE-2017-12611) | 9.8 | fixed in 2.5.10.1, 2.3.34 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2019-0230](https://nvd.nist.gov/vuln/detail/CVE-2019-0230) | 9.8 | fixed in 2.5.22 | 
critical | pom.xml | org.apache.struts_struts-core | [CVE-2020-17530](https://nvd.nist.gov/vuln/detail/CVE-2020-17530) | 9.8 | fixed in 2.5.26 | 
high | folder/requirements.txt | werkzeug | [CVE-2019-14806](https://nvd.nist.gov/vuln/detail/CVE-2019-14806) | 7.5 | fixed in 0.15.3 | 
high | requirements.txt | urllib3 | [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324) | 7.5 | fixed in 1.24.2 | 
high | requirements.txt | werkzeug | [CVE-2019-14806](https://nvd.nist.gov/vuln/detail/CVE-2019-14806) | 7.5 | fixed in 0.15.3 | 
high | package.json | js-yaml | [GHSA-8j8c-7jfh-h6hx](https://github.com/advisories/GHSA-8j8c-7jfh-h6hx) | 7.0 | fixed in 3.13.1 | 
high | folder/package.json | js-yaml | [GHSA-8j8c-7jfh-h6hx](https://github.com/advisories/GHSA-8j8c-7jfh-h6hx) | 7.0 | fixed in 3.13.1 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-12022](https://nvd.nist.gov/vuln/detail/CVE-2018-12022) | 7.5 | fixed in 2.9.6, 2.8.11.2, 2.7.9.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-12023](https://nvd.nist.gov/vuln/detail/CVE-2018-12023) | 7.5 | fixed in 2.9.6, 2.8.11.2, 2.7.9.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086) | 7.5 | fixed in 2.9.9 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14439](https://nvd.nist.gov/vuln/detail/CVE-2019-14439) | 7.5 | fixed in 2.9.9.2 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10672](https://nvd.nist.gov/vuln/detail/CVE-2020-10672) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10673](https://nvd.nist.gov/vuln/detail/CVE-2020-10673) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10968](https://nvd.nist.gov/vuln/detail/CVE-2020-10968) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10969](https://nvd.nist.gov/vuln/detail/CVE-2020-10969) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11111](https://nvd.nist.gov/vuln/detail/CVE-2020-11111) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11112](https://nvd.nist.gov/vuln/detail/CVE-2020-11112) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11113](https://nvd.nist.gov/vuln/detail/CVE-2020-11113) | 8.8 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11619](https://nvd.nist.gov/vuln/detail/CVE-2020-11619) | 8.1 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11620](https://nvd.nist.gov/vuln/detail/CVE-2020-11620) | 8.1 | fixed in 2.9.10.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14060](https://nvd.nist.gov/vuln/detail/CVE-2020-14060) | 8.1 | fixed in 2.9.10.5 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14061](https://nvd.nist.gov/vuln/detail/CVE-2020-14061) | 8.1 | fixed in 2.9.10.5 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14062](https://nvd.nist.gov/vuln/detail/CVE-2020-14062) | 8.1 | fixed in 2.9.10.5 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14195](https://nvd.nist.gov/vuln/detail/CVE-2020-14195) | 8.1 | fixed in 2.9.10.5 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24616](https://nvd.nist.gov/vuln/detail/CVE-2020-24616) | 8.1 | fixed in 2.9.10.6 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24750](https://nvd.nist.gov/vuln/detail/CVE-2020-24750) | 8.1 | fixed in 2.9.10.6 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) | 7.5 | fixed in 2.10.5.1, 2.9.10.7, 2.6.7.4 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35491](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35728](https://nvd.nist.gov/vuln/detail/CVE-2020-35728) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36179](https://nvd.nist.gov/vuln/detail/CVE-2020-36179) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36180](https://nvd.nist.gov/vuln/detail/CVE-2020-36180) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36181](https://nvd.nist.gov/vuln/detail/CVE-2020-36181) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36182](https://nvd.nist.gov/vuln/detail/CVE-2020-36182) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36183](https://nvd.nist.gov/vuln/detail/CVE-2020-36183) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36184](https://nvd.nist.gov/vuln/detail/CVE-2020-36184) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36185](https://nvd.nist.gov/vuln/detail/CVE-2020-36185) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36186](https://nvd.nist.gov/vuln/detail/CVE-2020-36186) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36187](https://nvd.nist.gov/vuln/detail/CVE-2020-36187) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36188](https://nvd.nist.gov/vuln/detail/CVE-2020-36188) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36189](https://nvd.nist.gov/vuln/detail/CVE-2020-36189) | 8.1 | fixed in 2.9.10.8 | 
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2021-20190](https://nvd.nist.gov/vuln/detail/CVE-2021-20190) | 8.1 | fixed in 2.9.10.7 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-0785](https://nvd.nist.gov/vuln/detail/CVE-2016-0785) | 8.8 | fixed in 2.3.28 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-3081](https://nvd.nist.gov/vuln/detail/CVE-2016-3081) | 8.1 | fixed in 2.3.28.1 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-3090](https://nvd.nist.gov/vuln/detail/CVE-2016-3090) | 8.8 | fixed in 2.3.20 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-4461](https://nvd.nist.gov/vuln/detail/CVE-2016-4461) | 8.8 | fixed in 2.3.29 | 
high | pom.xml | org.apache.struts_struts-core | [CVE-2019-0233](https://nvd.nist.gov/vuln/detail/CVE-2019-0233) | 7.5 | fixed in 2.5.22 | 
medium | folder/requirements.txt | werkzeug | [CVE-2016-10516](https://nvd.nist.gov/vuln/detail/CVE-2016-10516) | 6.1 | fixed in 0.11.11 | 
medium | folder/requirements.txt | werkzeug | [CVE-2020-28724](https://nvd.nist.gov/vuln/detail/CVE-2020-28724) | 6.1 | fixed in 0.11.6 | 
medium | requirements.txt | urllib3 | [CVE-2019-11236](https://nvd.nist.gov/vuln/detail/CVE-2019-11236) | 6.1 | fixed in 1.24.3 | 
medium | requirements.txt | urllib3 | [CVE-2020-26137](https://nvd.nist.gov/vuln/detail/CVE-2020-26137) | 6.5 | fixed in 1.25.9 | 
medium | requirements.txt | werkzeug | [CVE-2016-10516](https://nvd.nist.gov/vuln/detail/CVE-2016-10516) | 6.1 | fixed in 0.11.11 | 
medium | requirements.txt | werkzeug | [CVE-2020-28724](https://nvd.nist.gov/vuln/detail/CVE-2020-28724) | 6.1 | fixed in 0.11.6 | 
moderate | package.json | marked | [GHSA-xf5p-87ch-gxw2](https://github.com/advisories/GHSA-xf5p-87ch-gxw2) | 4.0 | fixed in 0.3.18 | 
medium | package.json | marked | [PRISMA-2021-0013]() | 0.0 | fixed in 1.1.1 | 
moderate | package.json | canvas | [GHSA-vpq5-4rc8-c222](https://github.com/advisories/GHSA-vpq5-4rc8-c222) | 4.0 | fixed in 1.6.10 | 
moderate | folder/package.json | marked | [GHSA-xf5p-87ch-gxw2](https://github.com/advisories/GHSA-xf5p-87ch-gxw2) | 4.0 | fixed in 0.3.18 | 
medium | folder/package.json | marked | [PRISMA-2021-0013]() | 0.0 | fixed in 1.1.1 | 
moderate | folder/package.json | canvas | [GHSA-vpq5-4rc8-c222](https://github.com/advisories/GHSA-vpq5-4rc8-c222) | 4.0 | fixed in 1.6.10 | 
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12384](https://nvd.nist.gov/vuln/detail/CVE-2019-12384) | 5.9 | fixed in 2.9.9.1 | 
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12814](https://nvd.nist.gov/vuln/detail/CVE-2019-12814) | 5.9 | fixed in 2.9.9.1 | 
medium | pom.xml | org.apache.struts_struts-core | [CVE-2016-2162](https://nvd.nist.gov/vuln/detail/CVE-2016-2162) | 6.1 | fixed in 2.3.25 | 
medium | pom.xml | org.apache.struts_struts-core | [CVE-2016-4003](https://nvd.nist.gov/vuln/detail/CVE-2016-4003) | 6.1 | fixed in 2.3.28, 1.8 | 
