### PR TITLE
Fix 12 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/folder/package.json
+++ b/folder/package.json
@@ -6,9 +6,9 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "3.13.0",
-    "marked": "0.3.15",
-    "canvas": "1.6.9"
+    "js-yaml": "3.13.1",
+    "marked": "4.0.10",
+    "canvas": "1.6.11"
   },
   "standard": {
     "globals": [

--- a/folder/requirements.txt
+++ b/folder/requirements.txt
@@ -1,7 +1,7 @@
-pyyaml==0.1
+pyyaml == 5.1 
 python-telegram-bot
 python-bugzilla
 pymongo
 telegram
 validate_email
-werkzeug==0.1
+werkzeug == 0.15.3 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "js-yaml": "3.13.0",
-    "marked": "0.3.15",
-    "canvas": "1.6.9"
+    "js-yaml": "3.13.1",
+    "marked": "4.0.10",
+    "canvas": "1.6.11"
   },
   "standard": {
     "globals": [

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
 <properties>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <surefire.version>2.0.1</surefire.version>
+    <surefire.version>2.5.26</surefire.version>
 </properties>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.5</version> <!-- ==> 2.10.0   -->
+      <version>2.10.5.1</version> <!-- ==> 2.10.0   -->
     </dependency>
     <dependency>
       <groupId>org.apache.struts</groupId>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # comment
-urllib3===1.24.1 # comment --> 1.24.3
+urllib3 == 1.26.5 # comment --> 1.24.3
 mysql-connector== ^1.0.0
 sdfsdf==1.0.0 
-werkzeug==0.1
+werkzeug == 0.15.3 


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Mon, 14 Mar 2022 09:23:04 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | folder/requirements.txt | pyyaml | [CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342) | 9.8 | fixed in 5.1 | In PyYAML before 5.1, the yaml.load() API could execute arbitrary code if used with untrusted data. The load() function has been deprecated in version 5.1 and the \'UnsafeLoader\' has been introduced for backward compatibility with the function.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9548](https://nvd.nist.gov/vuln/detail/CVE-2020-9548) | 9.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to br.com.anteros.dbcp.AnterosDBCPConfig (aka anteros-core).
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9547](https://nvd.nist.gov/vuln/detail/CVE-2020-9547) | 9.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to com.ibatis.sqlmap.engine.transaction.jta.JtaTransactionConfig (aka ibatis-sqlmap).
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-9546](https://nvd.nist.gov/vuln/detail/CVE-2020-9546) | 9.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.hadoop.shaded.com.zaxxer.hikari.HikariConfig (aka shaded hikari-config).
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-8840](https://nvd.nist.gov/vuln/detail/CVE-2020-8840) | 9.8 | fixed in 2.9.10.3, 2.8.11.5, 2.7.9.7 | FasterXML jackson-databind 2.0.0 through 2.9.10.2 lacks certain xbean-reflect/JNDI blocking, as demonstrated by org.apache.xbean.propertyeditor.JndiConverter.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19362](https://nvd.nist.gov/vuln/detail/CVE-2018-19362) | 9.8 | fixed in 2.9.8 | FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19361](https://nvd.nist.gov/vuln/detail/CVE-2018-19361) | 9.8 | fixed in 2.9.8 | FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the openjpa class from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-19360](https://nvd.nist.gov/vuln/detail/CVE-2018-19360) | 9.8 | fixed in 2.9.8 | FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the axis2-transport-jms class from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14379](https://nvd.nist.gov/vuln/detail/CVE-2019-14379) | 9.8 | fixed in 2.9.9.2 | SubTypeValidator.java in FasterXML jackson-databind before 2.9.9.2 mishandles default typing when ehcache is used (because of net.sf.ehcache.transaction.manager.DefaultTransactionManagerLookup), leading to remote code execution.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540) | 9.8 | fixed in 2.9.10 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to com.zaxxer.hikari.HikariConfig.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14721](https://nvd.nist.gov/vuln/detail/CVE-2018-14721) | 10.0 | fixed in 2.9.7 | FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to conduct server-side request forgery (SSRF) attacks by leveraging failure to block the axis2-jaxws class from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14720](https://nvd.nist.gov/vuln/detail/CVE-2018-14720) | 9.8 | fixed in 2.9.7 | FasterXML jackson-databind 2.x before 2.9.7 might allow attackers to conduct external XML entity (XXE) attacks by leveraging failure to block unspecified JDK classes from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14719](https://nvd.nist.gov/vuln/detail/CVE-2018-14719) | 9.8 | fixed in 2.9.7 | FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the blaze-ds-opt and blaze-ds-core classes from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-14718](https://nvd.nist.gov/vuln/detail/CVE-2018-14718) | 9.8 | fixed in 2.9.7 | FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the slf4j-ext class from polymorphic deserialization.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14892](https://nvd.nist.gov/vuln/detail/CVE-2019-14892) | 9.8 | fixed in 2.9.10, 2.8.11.5, 2.6.7.3 | A flaw was discovered in jackson-databind in versions before 2.9.10, 2.8.11.5 and 2.6.7.3, where it would permit polymorphic deserialization of a malicious object using commons-configuration 1 and 2 JNDI classes. An attacker could use this flaw to execute arbitrary code.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14893](https://nvd.nist.gov/vuln/detail/CVE-2019-14893) | 9.8 | fixed in 2.10.0, 2.9.10 | A flaw was discovered in FasterXML jackson-databind in all versions before 2.9.10 and 2.10.0, where it would permit polymorphic deserialization of malicious objects using the xalan JNDI gadget when used in conjunction with polymorphic type handling methods such as `enableDefaultTyping()` or when @JsonTypeInfo is using `Id.CLASS` or `Id.MINIMAL_CLASS` or in any other way which ObjectMapper.readValue might instantiate objects from unsafe sources. An attacker could use this flaw to execute arbitrary code.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335) | 9.8 | fixed in 2.9.10 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to com.zaxxer.hikari.HikariDataSource. This is a different vulnerability than CVE-2019-14540.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16942](https://nvd.nist.gov/vuln/detail/CVE-2019-16942) | 9.8 | fixed in 2.9.10.1, 2.8.11.5, 2.6.7.3 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the commons-dbcp (1.4) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of org.apache.commons.dbcp.datasources.SharedPoolDataSource and org.apache.commons.dbcp.datasources.PerUserPoolDataSource mishandling.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-16943](https://nvd.nist.gov/vuln/detail/CVE-2019-16943) | 9.8 | fixed in 2.9.10.1, 2.8.11.5, 2.6.7.3 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the p6spy (3.8.6) jar in the classpath, and an attacker can find an RMI service endpoint to access, it is possible to make the service execute a malicious payload. This issue exists because of com.p6spy.engine.spy.P6DataSource mishandling.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-17267](https://nvd.nist.gov/vuln/detail/CVE-2019-17267) | 9.8 | fixed in 2.9.10 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind before 2.9.10. It is related to net.sf.ehcache.hibernate.EhcacheJtaTransactionManagerLookup.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-17531](https://nvd.nist.gov/vuln/detail/CVE-2019-17531) | 9.8 | fixed in 2.9.10.1, 2.8.11.5, 2.6.7.3 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the apache-log4j-extra (version 1.2.x) jar in the classpath, and an attacker can provide a JNDI service to access, it is possible to make the service execute a malicious payload.
critical | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-20330](https://nvd.nist.gov/vuln/detail/CVE-2019-20330) | 9.8 | fixed in 2.9.10.2 | FasterXML jackson-databind 2.x before 2.9.10.2 lacks certain net.sf.ehcache blocking.
critical | pom.xml | org.apache.struts_struts-core | [CVE-2016-3082](https://nvd.nist.gov/vuln/detail/CVE-2016-3082) | 9.8 | fixed in 2.3.28.1, 2.3.24.2, 2.3.20.2 | XSLTResult in Apache Struts 2.x before 2.3.20.2, 2.3.24.x before 2.3.24.2, and 2.3.28.x before 2.3.28.1 allows remote attackers to execute arbitrary code via the stylesheet location parameter.
critical | pom.xml | org.apache.struts_struts-core | [CVE-2016-4436](https://nvd.nist.gov/vuln/detail/CVE-2016-4436) | 9.8 | fixed in 2.5.1, 2.3.29 | Apache Struts 2 before 2.3.29 and 2.5.x before 2.5.1 allow attackers to have unspecified impact via vectors related to improper action name clean up.
critical | pom.xml | org.apache.struts_struts-core | [CVE-2020-17530](https://nvd.nist.gov/vuln/detail/CVE-2020-17530) | 9.8 | fixed in 2.5.26 | Forced OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution. Affected software : Apache Struts 2.0.0 - Struts 2.5.25.
critical | pom.xml | org.apache.struts_struts-core | [CVE-2019-0230](https://nvd.nist.gov/vuln/detail/CVE-2019-0230) | 9.8 | fixed in 2.5.22 | Apache Struts 2.0.0 to 2.5.20 forced double OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution.
critical | pom.xml | org.apache.struts_struts-core | [CVE-2017-12611](https://nvd.nist.gov/vuln/detail/CVE-2017-12611) | 9.8 | fixed in 2.5.10.1, 2.3.34 | In Apache Struts 2.0.0 through 2.3.33 and 2.5 through 2.5.10.1, using an unintentional expression in a Freemarker tag instead of string literals can lead to a RCE attack.
high | folder/requirements.txt | werkzeug | [CVE-2019-14806](https://nvd.nist.gov/vuln/detail/CVE-2019-14806) | 7.5 | fixed in 0.15.3 | Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger PIN randomness because Docker containers share the same machine id.
high | requirements.txt | urllib3 | [CVE-2021-33503](https://nvd.nist.gov/vuln/detail/CVE-2021-33503) | 7.5 | fixed in 1.26.5 | An issue was discovered in urllib3 before 1.26.5. When provided with a URL containing many @ characters in the authority component, the authority regular expression exhibits catastrophic backtracking, causing a denial of service if a URL were passed as a parameter or redirected to via an HTTP redirect.
high | requirements.txt | urllib3 | [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324) | 7.5 | fixed in 1.24.2 | The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.
high | requirements.txt | werkzeug | [CVE-2019-14806](https://nvd.nist.gov/vuln/detail/CVE-2019-14806) | 7.5 | fixed in 0.15.3 | Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger PIN randomness because Docker containers share the same machine id.
high | package.json | marked | [CVE-2022-21681](https://github.com/advisories/GHSA-5v2h-r2cx-5xgj) | 7.0 | fixed in 4.0.10 | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `inline.reflinkSearch` may cause catastrophic backtracking against some strings and lead to a denial of service (DoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
high | package.json | marked | [CVE-2022-21680](https://github.com/advisories/GHSA-rrrm-qjm4-v8hf) | 7.0 | fixed in 4.0.10 | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `block.def` may cause catastrophic backtracking against some strings and lead to a regular expression denial of service (ReDoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
high | package.json | canvas | [CVE-2020-8215](https://nvd.nist.gov/vuln/detail/CVE-2020-8215) | 7.0 | fixed in 1.6.11 | A buffer overflow is present in canvas version <= 1.6.9, which could lead to a Denial of Service or execution of arbitrary code when it processes a user-provided image.
high | package.json | js-yaml | [GHSA-8j8c-7jfh-h6hx](https://github.com/advisories/GHSA-8j8c-7jfh-h6hx) | 7.0 | fixed in 3.13.1 | Versions of `js-yaml` prior to 3.13.1 are vulnerable to Code Injection. The `load()` function may execute arbitrary code injected through a malicious YAML file. Objects that have `toString` as key, JavaScript code as value and are used as explicit mapping keys allow attackers to execute the supplied code through the `load()` function. The `safeLoad()` function is unaffected.  An example payload is  `{ toString: !<tag:yaml.org,2002:js/function> \'function (){return Date.now()}\' } : 1`  which returns the object  {   \"1553107949161\": 1 }   ## Recommendation  Upgrade to version 3.13.1.
high | folder/package.json | canvas | [CVE-2020-8215](https://nvd.nist.gov/vuln/detail/CVE-2020-8215) | 7.0 | fixed in 1.6.11 | A buffer overflow is present in canvas version <= 1.6.9, which could lead to a Denial of Service or execution of arbitrary code when it processes a user-provided image.
high | folder/package.json | js-yaml | [GHSA-8j8c-7jfh-h6hx](https://github.com/advisories/GHSA-8j8c-7jfh-h6hx) | 7.0 | fixed in 3.13.1 | Versions of `js-yaml` prior to 3.13.1 are vulnerable to Code Injection. The `load()` function may execute arbitrary code injected through a malicious YAML file. Objects that have `toString` as key, JavaScript code as value and are used as explicit mapping keys allow attackers to execute the supplied code through the `load()` function. The `safeLoad()` function is unaffected.  An example payload is  `{ toString: !<tag:yaml.org,2002:js/function> \'function (){return Date.now()}\' } : 1`  which returns the object  {   \"1553107949161\": 1 }   ## Recommendation  Upgrade to version 3.13.1.
high | folder/package.json | marked | [CVE-2022-21681](https://github.com/advisories/GHSA-5v2h-r2cx-5xgj) | 7.0 | fixed in 4.0.10 | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `inline.reflinkSearch` may cause catastrophic backtracking against some strings and lead to a denial of service (DoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
high | folder/package.json | marked | [CVE-2022-21680](https://github.com/advisories/GHSA-rrrm-qjm4-v8hf) | 7.0 | fixed in 4.0.10 | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `block.def` may cause catastrophic backtracking against some strings and lead to a regular expression denial of service (ReDoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2021-20190](https://nvd.nist.gov/vuln/detail/CVE-2021-20190) | 8.1 | fixed in 2.9.10.7 | A flaw was found in jackson-databind before 2.9.10.7. FasterXML mishandles the interaction between serialization gadgets and typing. The highest threat from this vulnerability is to data confidentiality and integrity as well as system availability.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36189](https://nvd.nist.gov/vuln/detail/CVE-2020-36189) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36188](https://nvd.nist.gov/vuln/detail/CVE-2020-36188) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36187](https://nvd.nist.gov/vuln/detail/CVE-2020-36187) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36186](https://nvd.nist.gov/vuln/detail/CVE-2020-36186) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36185](https://nvd.nist.gov/vuln/detail/CVE-2020-36185) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36184](https://nvd.nist.gov/vuln/detail/CVE-2020-36184) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36183](https://nvd.nist.gov/vuln/detail/CVE-2020-36183) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36182](https://nvd.nist.gov/vuln/detail/CVE-2020-36182) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36181](https://nvd.nist.gov/vuln/detail/CVE-2020-36181) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36180](https://nvd.nist.gov/vuln/detail/CVE-2020-36180) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36179](https://nvd.nist.gov/vuln/detail/CVE-2020-36179) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35728](https://nvd.nist.gov/vuln/detail/CVE-2020-35728) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool (aka embedded Xalan in org.glassfish.web/javax.servlet.jsp.jstl).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35491](https://nvd.nist.gov/vuln/detail/CVE-2020-35491) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.SharedPoolDataSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-35490](https://nvd.nist.gov/vuln/detail/CVE-2020-35490) | 8.1 | fixed in 2.9.10.8 | FasterXML jackson-databind 2.x before 2.9.10.8 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.PerUserPoolDataSource.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) | 7.5 | fixed in 2.10.5.1, 2.9.10.7, 2.6.7.4 | A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24750](https://nvd.nist.gov/vuln/detail/CVE-2020-24750) | 8.1 | fixed in 2.9.10.6 | FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to com.pastdev.httpcomponents.configuration.JndiConfiguration.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-24616](https://nvd.nist.gov/vuln/detail/CVE-2020-24616) | 8.1 | fixed in 2.9.10.6 | FasterXML jackson-databind 2.x before 2.9.10.6 mishandles the interaction between serialization gadgets and typing, related to br.com.anteros.dbcp.AnterosDBCPDataSource (aka Anteros-DBCP).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086) | 7.5 | fixed in 2.9.9 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint, the service has the mysql-connector-java jar (8.0.14 or earlier) in the classpath, and an attacker can host a crafted MySQL server reachable by the victim, an attacker can send a crafted JSON message that allows them to read arbitrary local files on the server. This occurs because of missing com.mysql.cj.jdbc.admin.MiniAdmin validation.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14195](https://nvd.nist.gov/vuln/detail/CVE-2020-14195) | 8.1 | fixed in 2.9.10.5 | FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to org.jsecurity.realm.jndi.JndiRealmFactory (aka org.jsecurity).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14062](https://nvd.nist.gov/vuln/detail/CVE-2020-14062) | 8.1 | fixed in 2.9.10.5 | FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool (aka xalan2).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14061](https://nvd.nist.gov/vuln/detail/CVE-2020-14061) | 8.1 | fixed in 2.9.10.5 | FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to oracle.jms.AQjmsQueueConnectionFactory, oracle.jms.AQjmsXATopicConnectionFactory, oracle.jms.AQjmsTopicConnectionFactory, oracle.jms.AQjmsXAQueueConnectionFactory, and oracle.jms.AQjmsXAConnectionFactory (aka weblogic/oracle-aqjms).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-14060](https://nvd.nist.gov/vuln/detail/CVE-2020-14060) | 8.1 | fixed in 2.9.10.5 | FasterXML jackson-databind 2.x before 2.9.10.5 mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.xalan.lib.sql.JNDIConnectionPool (aka apache/drill).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-14439](https://nvd.nist.gov/vuln/detail/CVE-2019-14439) | 7.5 | fixed in 2.9.9.2 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x before 2.9.9.2. This occurs when Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the logback jar in the classpath.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-12023](https://nvd.nist.gov/vuln/detail/CVE-2018-12023) | 7.5 | fixed in 2.9.6, 2.8.11.2, 2.7.9.4 | An issue was discovered in FasterXML jackson-databind prior to 2.7.9.4, 2.8.11.2, and 2.9.6. When Default Typing is enabled (either globally or for a specific property), the service has the Oracle JDBC jar in the classpath, and an attacker can provide an LDAP service to access, it is possible to make the service execute a malicious payload.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2018-12022](https://nvd.nist.gov/vuln/detail/CVE-2018-12022) | 7.5 | fixed in 2.9.6, 2.8.11.2, 2.7.9.4 | An issue was discovered in FasterXML jackson-databind prior to 2.7.9.4, 2.8.11.2, and 2.9.6. When Default Typing is enabled (either globally or for a specific property), the service has the Jodd-db jar (for database access for the Jodd framework) in the classpath, and an attacker can provide an LDAP service to access, it is possible to make the service execute a malicious payload.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11620](https://nvd.nist.gov/vuln/detail/CVE-2020-11620) | 8.1 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.jelly.impl.Embedded (aka commons-jelly).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11619](https://nvd.nist.gov/vuln/detail/CVE-2020-11619) | 8.1 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.springframework.aop.config.MethodLocatingFactoryBean (aka spring-aop).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11113](https://nvd.nist.gov/vuln/detail/CVE-2020-11113) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.openjpa.ee.WASRegistryManagedRuntime (aka openjpa).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11112](https://nvd.nist.gov/vuln/detail/CVE-2020-11112) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.proxy.provider.remoting.RmiProvider (aka apache/commons-proxy).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-11111](https://nvd.nist.gov/vuln/detail/CVE-2020-11111) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.activemq.* (aka activemq-jms, activemq-core, activemq-pool, and activemq-pool-jms).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10969](https://nvd.nist.gov/vuln/detail/CVE-2020-10969) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to javax.swing.JEditorPane.
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10968](https://nvd.nist.gov/vuln/detail/CVE-2020-10968) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.aoju.bus.proxy.provider.remoting.RmiProvider (aka bus-proxy).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10672](https://nvd.nist.gov/vuln/detail/CVE-2020-10672) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to org.apache.aries.transaction.jms.internal.XaPooledConnectionFactory (aka aries.transaction.jms).
high | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-10673](https://nvd.nist.gov/vuln/detail/CVE-2020-10673) | 8.8 | fixed in 2.9.10.4 | FasterXML jackson-databind 2.x before 2.9.10.4 mishandles the interaction between serialization gadgets and typing, related to com.caucho.config.types.ResourceRef (aka caucho-quercus).
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-0785](https://nvd.nist.gov/vuln/detail/CVE-2016-0785) | 8.8 | fixed in 2.3.28 | Apache Struts 2.x before 2.3.28 allows remote attackers to execute arbitrary code via a \"%{}\" sequence in a tag attribute, aka forced double OGNL evaluation.
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-3081](https://nvd.nist.gov/vuln/detail/CVE-2016-3081) | 8.1 | fixed in 2.3.28.1 | Apache Struts 2.3.19 to 2.3.20.2, 2.3.21 to 2.3.24.1, and 2.3.25 to 2.3.28, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via method: prefix, related to chained expressions.
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-3090](https://nvd.nist.gov/vuln/detail/CVE-2016-3090) | 8.8 | fixed in 2.3.20 | The TextParseUtil.translateVariables method in Apache Struts 2.x before 2.3.20 allows remote attackers to execute arbitrary code via a crafted OGNL expression with ANTLR tooling.
high | pom.xml | org.apache.struts_struts-core | [CVE-2016-4461](https://nvd.nist.gov/vuln/detail/CVE-2016-4461) | 8.8 | fixed in 2.3.29 | Apache Struts 2.x before 2.3.29 allows remote attackers to execute arbitrary code via a \"%{}\" sequence in a tag attribute, aka forced double OGNL evaluation.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2016-0785.
high | pom.xml | org.apache.struts_struts-core | [CVE-2019-0233](https://nvd.nist.gov/vuln/detail/CVE-2019-0233) | 7.5 | fixed in 2.5.22 | An access permission override in Apache Struts 2.0.0 to 2.5.20 may cause a Denial of Service when performing a file upload.
medium | folder/requirements.txt | werkzeug | [CVE-2016-10516](https://nvd.nist.gov/vuln/detail/CVE-2016-10516) | 6.1 | fixed in 0.11.11 | Cross-site scripting (XSS) vulnerability in the render_full function in debug/tbtools.py in the debugger in Pallets Werkzeug before 0.11.11 (as used in Pallets Flask and other products) allows remote attackers to inject arbitrary web script or HTML via a field that contains an exception message.
medium | folder/requirements.txt | werkzeug | [CVE-2020-28724](https://nvd.nist.gov/vuln/detail/CVE-2020-28724) | 6.1 | fixed in 0.11.6 | Open redirect vulnerability in werkzeug before 0.11.6 via a double slash in the URL.
medium | requirements.txt | urllib3 | [CVE-2020-26137](https://nvd.nist.gov/vuln/detail/CVE-2020-26137) | 6.5 | fixed in 1.25.9 | urllib3 before 1.25.9 allows CRLF injection if the attacker controls the HTTP request method, as demonstrated by inserting CR and LF control characters in the first argument of putrequest(). NOTE: this is similar to CVE-2020-26116.
medium | requirements.txt | urllib3 | [CVE-2019-11236](https://nvd.nist.gov/vuln/detail/CVE-2019-11236) | 6.1 | fixed in 1.24.3 | In the urllib3 library through 1.24.1 for Python, CRLF injection is possible if the attacker controls the request parameter.
medium | requirements.txt | werkzeug | [CVE-2016-10516](https://nvd.nist.gov/vuln/detail/CVE-2016-10516) | 6.1 | fixed in 0.11.11 | Cross-site scripting (XSS) vulnerability in the render_full function in debug/tbtools.py in the debugger in Pallets Werkzeug before 0.11.11 (as used in Pallets Flask and other products) allows remote attackers to inject arbitrary web script or HTML via a field that contains an exception message.
medium | requirements.txt | werkzeug | [CVE-2020-28724](https://nvd.nist.gov/vuln/detail/CVE-2020-28724) | 6.1 | fixed in 0.11.6 | Open redirect vulnerability in werkzeug before 0.11.6 via a double slash in the URL.
medium | package.json | marked | [PRISMA-2021-0013]() | 0.0 | fixed in 1.1.1 | marked package prior to 1.1.1 are vulnerable to  Regular Expression Denial of Service (ReDoS). The regex within src/rules.js file have multiple unused capture groups which could lead to a denial of service attack if user input is reachable.  Origin: https://github.com/markedjs/marked/commit/bd4f8c464befad2b304d51e33e89e567326e62e0
moderate | package.json | marked | [GHSA-xf5p-87ch-gxw2](https://www.npmjs.com/advisories/812) | 5.3 | fixed in 0.6.2 | Versions of marked prior to 0.6.2 and later than 0.3.14 are vulnerable to Regular Expression Denial of Service. Email addresses may be evaluated in quadratic time, allowing attackers to potentially crash the node process due to resource exhaustion.
moderate | package.json | canvas | [GHSA-vpq5-4rc8-c222](https://github.com/advisories/GHSA-vpq5-4rc8-c222) | 4.0 | fixed in 1.6.10 | Versions of `canvas` prior to 1.6.10 are vulnerable to Denial of Service. Processing malicious JPEGs or GIFs could crash the node process.   ## Recommendation  Upgrade to version 1.6.10
moderate | folder/package.json | canvas | [GHSA-vpq5-4rc8-c222](https://github.com/advisories/GHSA-vpq5-4rc8-c222) | 4.0 | fixed in 1.6.10 | Versions of `canvas` prior to 1.6.10 are vulnerable to Denial of Service. Processing malicious JPEGs or GIFs could crash the node process.   ## Recommendation  Upgrade to version 1.6.10
medium | folder/package.json | marked | [PRISMA-2021-0013]() | 0.0 | fixed in 1.1.1 | marked package prior to 1.1.1 are vulnerable to  Regular Expression Denial of Service (ReDoS). The regex within src/rules.js file have multiple unused capture groups which could lead to a denial of service attack if user input is reachable.  Origin: https://github.com/markedjs/marked/commit/bd4f8c464befad2b304d51e33e89e567326e62e0
moderate | folder/package.json | marked | [GHSA-xf5p-87ch-gxw2](https://www.npmjs.com/advisories/812) | 5.3 | fixed in 0.6.2 | Versions of marked prior to 0.6.2 and later than 0.3.14 are vulnerable to Regular Expression Denial of Service. Email addresses may be evaluated in quadratic time, allowing attackers to potentially crash the node process due to resource exhaustion.
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12384](https://nvd.nist.gov/vuln/detail/CVE-2019-12384) | 5.9 | fixed in 2.9.9.1 | FasterXML jackson-databind 2.x before 2.9.9.1 might allow attackers to have a variety of impacts by leveraging failure to block the logback-core class from polymorphic deserialization. Depending on the classpath content, remote code execution may be possible.
medium | pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2019-12814](https://nvd.nist.gov/vuln/detail/CVE-2019-12814) | 5.9 | fixed in 2.9.9.1 | A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically crafted JSON message that allows them to read arbitrary local files on the server.
medium | pom.xml | org.apache.struts_struts-core | [CVE-2016-2162](https://nvd.nist.gov/vuln/detail/CVE-2016-2162) | 6.1 | fixed in 2.3.25 | Apache Struts 2.x before 2.3.25 does not sanitize text in the Locale object constructed by I18NInterceptor, which might allow remote attackers to conduct cross-site scripting (XSS) attacks via unspecified vectors involving language display.
medium | pom.xml | org.apache.struts_struts-core | [CVE-2016-4003](https://nvd.nist.gov/vuln/detail/CVE-2016-4003) | 6.1 | fixed in 2.3.28, 1.8 | Cross-site scripting (XSS) vulnerability in the URLDecoder function in JRE before 1.8, as used in Apache Struts 2.x before 2.3.28, when using a single byte page encoding, allows remote attackers to inject arbitrary web script or HTML via multi-byte characters in a url-encoded parameter.
